### PR TITLE
[infra] adiciona configuração de tema do tailwind

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -7,5 +7,5 @@
   --color-project-purple: #6C2365;
   --color-project-green: #22C55E;
   --color-project-secondary-green: #86EFAC;
-  --color-porject-background-gray: #DBDBDB;
+  --color-project-background-gray: #DBDBDB;
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
 
 @theme {
   --font-roboto: "Roboto", sans-serif;
@@ -8,5 +8,4 @@
   --color-project-green: #22C55E;
   --color-project-secondary-green: #86EFAC;
   --color-porject-background-gray: #DBDBDB;
-
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,12 @@
 @import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+
+@theme {
+  --font-roboto: "Roboto", sans-serif;
+
+  --color-project-purple: #6C2365;
+  --color-project-green: #22C55E;
+  --color-project-secondary-green: #86EFAC;
+  --color-porject-background-gray: #DBDBDB;
+
+}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,8 +2,8 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Configure 'rails notes' to inspect Cucumber files
-  config.annotations.register_directories('features')
-  config.annotations.register_extensions('feature') { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
+  config.annotations.register_directories("features")
+  config.annotations.register_extensions("feature") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,8 +5,8 @@
 
 Rails.application.configure do
   # Configure 'rails notes' to inspect Cucumber files
-  config.annotations.register_directories('features')
-  config.annotations.register_extensions('feature') { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
+  config.annotations.register_directories("features")
+  config.annotations.register_extensions("feature") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -5,46 +5,45 @@
 # files.
 
 
-unless ARGV.any? {|a| a =~ /^gems/} # Don't load anything when running the gems:* tasks
+unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gems:* tasks
 
 vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
-$LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
+$LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + "/../lib") unless vendored_cucumber_bin.nil?
 
 begin
-  require 'cucumber/rake/task'
+  require "cucumber/rake/task"
 
   namespace :cucumber do
-    Cucumber::Rake::Task.new({ok: 'test:prepare'}, 'Run features that should pass') do |t|
+    Cucumber::Rake::Task.new({ ok: "test:prepare" }, "Run features that should pass") do |t|
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'default'
+      t.profile = "default"
     end
 
-    Cucumber::Rake::Task.new({wip: 'test:prepare'}, 'Run features that are being worked on') do |t|
+    Cucumber::Rake::Task.new({ wip: "test:prepare" }, "Run features that are being worked on") do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'wip'
+      t.profile = "wip"
     end
 
-    Cucumber::Rake::Task.new({rerun: 'test:prepare'}, 'Record failing features and run only them if any exist') do |t|
+    Cucumber::Rake::Task.new({ rerun: "test:prepare" }, "Record failing features and run only them if any exist") do |t|
       t.binary = vendored_cucumber_bin
       t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'rerun'
+      t.profile = "rerun"
     end
 
-    desc 'Run all features'
-    task all: [:ok, :wip]
+    desc "Run all features"
+    task all: [ :ok, :wip ]
 
     task :statsetup do
-      require 'rails/code_statistics'
-      ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
-      ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
+      require "rails/code_statistics"
+      ::STATS_DIRECTORIES << %w[Cucumber\ features features] if File.exist?("features")
+      ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?("features")
     end
-    
   end
 
-  desc 'Alias for cucumber:ok'
-  task cucumber: 'cucumber:ok'
+  desc "Alias for cucumber:ok"
+  task cucumber: "cucumber:ok"
 
   task default: :cucumber
 
@@ -53,16 +52,16 @@ begin
   end
 
   # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.
-  task 'test:prepare' do
+  task "test:prepare" do
   end
 
-  task stats: 'cucumber:statsetup'
+  task stats: "cucumber:statsetup"
 
-  
+
 rescue LoadError
-  desc 'cucumber rake task not available (cucumber not installed)'
+  desc "cucumber rake task not available (cucumber not installed)"
   task :cucumber do
-    abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
+    abort "Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin"
   end
 end
 


### PR DESCRIPTION
Ao fazer uma pesquisa, nas versão mais recentes do tailwind a configuração de tema não está sendo mais feita no arquivo `config/tailwind.config.js`, passando a ser no arquivo `app/assets/tailwind/application.css`. Exemplo de uso de cores e da fonte roboto `<button class="font-roboto bg-project-purple"> test </button>`